### PR TITLE
fix: image width responsive

### DIFF
--- a/public/scss/pages/Article.module.scss
+++ b/public/scss/pages/Article.module.scss
@@ -53,13 +53,15 @@
       margin: 0;
     }
 
-    img{
+    img
+    {
       max-width: 100%;
       height: auto;
     }
 
     iframe,
-    video{
+    video
+    {
       max-width: 100%;
     }
   }

--- a/public/scss/pages/Article.module.scss
+++ b/public/scss/pages/Article.module.scss
@@ -52,6 +52,16 @@
       color: $color_black_text;
       margin: 0;
     }
+
+    img{
+      max-width: 100%;
+      height: auto;
+    }
+
+    iframe,
+    video{
+      max-width: 100%;
+    }
   }
 
   &_categoriesTitle


### PR DESCRIPTION
<img width="1439" alt="Screen Shot 2022-07-06 at 14 55 41" src="https://user-images.githubusercontent.com/8541505/177500287-74fe39e0-8102-4f8a-961b-e1e9b2ec066f.png">
<img width="1433" alt="Screen Shot 2022-07-06 at 14 56 08" src="https://user-images.githubusercontent.com/8541505/177500336-ff460a03-1238-4167-9c04-0e48be0223d0.png">
<img width="399" alt="Screen Shot 2022-07-06 at 14 56 42" src="https://user-images.githubusercontent.com/8541505/177500396-0ea9b91f-0341-4564-99ac-5d7050759afd.png">
<img width="400" alt="Screen Shot 2022-07-06 at 14 56 57" src="https://user-images.githubusercontent.com/8541505/177500399-263e96b9-8fc2-4414-8361-3f88eeade942.png">
