### PR TITLE
fix: increase width thumbor in logo header

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -85,7 +85,7 @@ const Header: FC<any> = ({
               <Logo
                 imageClassName={styles.header_logo}
                 thumborSetting={{
-                  width: size.width < 575 ? 300 : 400,
+                  width: size.width < 575 ? 350 : 400,
                   quality: 90
                 }}
                 lazyLoadedImage={false}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -85,7 +85,7 @@ const Header: FC<any> = ({
               <Logo
                 imageClassName={styles.header_logo}
                 thumborSetting={{
-                  width: size.width < 575 ? 200 : 400,
+                  width: size.width < 575 ? 300 : 400,
                   quality: 90
                 }}
                 lazyLoadedImage={false}


### PR DESCRIPTION
Before:
<img width="178" alt="Screenshot 2022-07-08 092422" src="https://user-images.githubusercontent.com/45808774/177904942-5ca54663-bf32-4f95-819f-4f5ea91833c3.png">

<img width="383" alt="Screenshot 2022-07-08 092503" src="https://user-images.githubusercontent.com/45808774/177904947-cf94347e-5a61-496f-8b08-616757d945e3.png">

After:
<img width="395" alt="Screenshot 2022-07-08 105244" src="https://user-images.githubusercontent.com/45808774/177913655-876f6fc4-7272-4a39-a2cb-9656be282e39.png">

---
Using Real Mobile

Before
![Screenshot_20220708-092327_Chrome](https://user-images.githubusercontent.com/45808774/177905047-cb760a53-5898-46db-90ad-9d94677bd3b4.jpg)

After
![sc](https://user-images.githubusercontent.com/45808774/177913996-03bc7a93-206c-47ec-9a08-886f50ad4cf1.jpeg)

