### PR TITLE
fix: widget ratio

### DIFF
--- a/public/scss/components/WidgetHomePage.module.scss
+++ b/public/scss/components/WidgetHomePage.module.scss
@@ -25,7 +25,7 @@
 
   &_itemTop
   {
-    @include position();
+    position: relative;
     margin-top: 41px;
     margin-bottom: 42px;
    
@@ -37,7 +37,7 @@
     
     &:first-child
     {
-      width: calc(((100% - 12px) / 12) * 7);
+      width: calc(((100% - 12px) / 12) * 6);
 
       h1, h2, h3, h4, h5, p
       {
@@ -54,7 +54,7 @@
     
     &:last-child
     {
-      width: calc(((100% - 12px) / 12) * 5);
+      width: calc(((100% - 12px) / 12) * 6);
 
       h1, h2, h3, h4, h5, p
       {
@@ -73,7 +73,7 @@
     img
     {
       @include fixedWidth(100%, true);
-      object-fit: contain;
+      @include fixedHeight(auto, true);
     }
   }
 
@@ -143,7 +143,7 @@
 
   &_itemBottom
   {
-    @include position();
+    position: relative;
 
     &:hover{
       cursor: pointer;
@@ -152,7 +152,7 @@
     
     &:last-child
     {
-      width: calc(((100% - 12px) / 12) * 7);
+      width: calc(((100% - 12px) / 12) * 6);
 
       h1, h2, h3, h4, h5, p
       {
@@ -174,7 +174,7 @@
     
     &:first-child
     {
-      width: calc(((100% - 12px) / 12) * 5);
+      width: calc(((100% - 12px) / 12) * 6);
       text-align: center;
       
       h1, h2, h3, h4, h5, p
@@ -193,7 +193,7 @@
     img
     {
       @include fixedWidth(100%, true);
-      object-fit: contain;
+      @include fixedHeight(auto, true);
     }
   }
 


### PR DESCRIPTION
> Problem 2
> https://sirclo.slack.com/archives/C01JM4J6124/p1655087689939899
> Kolom widget kiri dan kanan 7:5, dari user kesulitan untuk menyesuaikan imagenya supaya pas.
> 
> Solusinya
> Dari UI/UX [@sf](https://phabricator.sirclo.com/p/sf/) setuju untuk setiap widgetnya, kolomnya diganti dengan perbandingan 1:1. Jadi diasumsikan user akan isi image asli dengan ukuran yang sama.

**Hasil :**

**Desktop**
![Screenshot 2022-07-12 at 14-10-05 Beranda](https://user-images.githubusercontent.com/16263184/178431408-2379820d-5d3b-4fea-9b3b-328e18c5643c.png)

**Mobile** 
![WhatsApp Image 2022-07-12 at 2 18 48 PM](https://user-images.githubusercontent.com/16263184/178433258-86213f4c-be68-40dd-b8c2-15f7a75c5fde.jpeg)

![WhatsApp Image 2022-07-12 at 2 22 34 PM](https://user-images.githubusercontent.com/16263184/178433129-ea55f350-2942-4241-ad18-76c4f81b5cc9.jpeg)
