### PR TITLE
fix(instagram-feed): display none if instagram account doesn't connected

### DIFF
--- a/components/Instagram/index.tsx
+++ b/components/Instagram/index.tsx
@@ -1,5 +1,5 @@
 /* library package */
-import { FC } from 'react'
+import { FC, useState } from 'react'
 /* component */
 import { InstagramFeed } from '@sirclo/nexus'
 import Placeholder from 'components/Placeholder'
@@ -34,6 +34,7 @@ const Instagram: FC<iProps> = ({
   i18n,
   brand
 }) => {
+  const [isIGConnected, setIsIGConnected] = useState<boolean>(true)
   const postLimit = size.width < 768 ? 4 : 7
 
   const handleFollowButton = () => {
@@ -41,7 +42,7 @@ const Instagram: FC<iProps> = ({
   }
 
   return (
-    <div className={classesInstagramFeed.layoutClassName}>
+    <div className={isIGConnected ? classesInstagramFeed.layoutClassName : "d-none"}>
       <InstagramFeed
         slidesPerPage={size.width < 768 ? false : 6}
         slidesPerScroll={size.width < 768 ? false : 1}
@@ -55,6 +56,7 @@ const Instagram: FC<iProps> = ({
           format: 'webp',
         }}
         classes={classesInstagramFeed}
+        onErrorStatus={(status) => setIsIGConnected(!status)}
         loadingComponent={
           <div className={classesInstagramFeed.containerClassName}>
             <Placeholder classes={classesPlaceholderCollapsibleNav} withImage />

--- a/public/scss/components/Instagram.module.scss
+++ b/public/scss/components/Instagram.module.scss
@@ -6,11 +6,9 @@
   &_container
   {
     @include flex(row,center,center);
-    margin-top:80px;
     
     @media screen and (max-width: $breakpoint_max_md) 
     {
-      margin-top:42px;
       @include flex(row,center,center,wrap);
     }
   }
@@ -71,5 +69,3 @@
     margin: 22px 0 10px 0;
   }
 }
-
-

--- a/public/scss/pages/Home.module.scss
+++ b/public/scss/pages/Home.module.scss
@@ -16,7 +16,13 @@
     background-color: $color_light_dark;
     color: $color_black;
     margin-top: 42px;
+    margin-bottom: 80px;
     cursor: pointer;
+    
+    @media screen and (max-width: $breakpoint_max_md) 
+    {
+      margin-bottom: 42px;
+    }
 
     & > img 
     {


### PR DESCRIPTION
Task: https://phabricator.sirclo.com/T36833

**Screenshots:**
- Instagram account connected
![desktop instagram connected](https://user-images.githubusercontent.com/55394860/186638447-84ae7201-ce04-4678-a5cb-69063cb05ae1.png)
![mobile instagram connected](https://user-images.githubusercontent.com/55394860/186638479-ed85317c-2876-4757-8fc0-a1d324a45088.png)

- Instagram account doesn't connected
![desktop instagram disconnected](https://user-images.githubusercontent.com/55394860/186638465-d52a8b53-0093-4470-879c-8628d0b8d0dd.png)
![mobile instagram disconnected](https://user-images.githubusercontent.com/55394860/186638481-2372d59d-bb69-4bd4-90f4-d5c69d4edf28.png)

- Instagram account connected with empty feed
![desktop instagram connected with empty feed](https://user-images.githubusercontent.com/55394860/186638483-e9a20b1a-8494-4edd-986f-a843578a6ceb.png)
![mobile instagram connected with empty feed](https://user-images.githubusercontent.com/55394860/186638473-ac9ca633-fd96-44a9-8665-e8309e5b8313.png)