### PR TITLE
fix: remove z-index in contact page

### DIFF
--- a/public/scss/pages/Contact.module.scss
+++ b/public/scss/pages/Contact.module.scss
@@ -19,7 +19,6 @@
   {
     width: calc(((100% - 24px) / 12) * 6);
     position: relative;
-    z-index: 10;
     padding-bottom: 224px;
     margin-bottom: 64px;
 


### PR DESCRIPTION
Tampilan:
Jika Side Bar tidak diklik
<img width="960" alt="image" src="https://user-images.githubusercontent.com/45808774/191480595-7255d720-bd81-41d7-8278-d79f300990fe.png">
<img width="161" alt="image" src="https://user-images.githubusercontent.com/45808774/191480644-f8f318fb-d66c-44f2-ac6d-5c71d3c2185a.png">

Side Bar diklik
<img width="960" alt="image" src="https://user-images.githubusercontent.com/45808774/191480680-b13e9e3b-3b66-406f-82df-45671aa1d95f.png">

<img width="148" alt="image" src="https://user-images.githubusercontent.com/45808774/191480759-afe8c921-0bfe-4062-9413-2acc3c050b80.png">

Video kalau discroll
https://drive.google.com/drive/folders/1Phenkw-cHQmMbLpjKXYE-8aRhZU_5Aun?usp=sharing