### PR TITLE
Fix: enable coupon detail button

### DIFF
--- a/public/scss/components/OrderSummaryBox.module.scss
+++ b/public/scss/components/OrderSummaryBox.module.scss
@@ -354,8 +354,13 @@
 
   &_voucherDetailInvalid
   {
-    opacity: .5;
-    pointer-events: none;
+    cursor: default !important;
+    
+    & > [class*="voucherDetail_"]
+    {
+      opacity: .5;
+      pointer-events: none;
+    }
   }
 
   &_voucherListItems
@@ -929,6 +934,7 @@
     {
       @include flex(row, center, center);
       padding: 8px 0;
+      margin-top: 8px;
       
       @media screen and (max-width: $breakpoint_max_sm)
       {

--- a/public/scss/components/OrderSummaryBox.module.scss
+++ b/public/scss/components/OrderSummaryBox.module.scss
@@ -907,6 +907,11 @@
     background: $color_black_text;
     border-radius: 2px;
     border: 0;
+
+    &:disabled
+    {
+      background: $color_light;
+    }
   }
 
   &_voucherDetailApplied


### PR DESCRIPTION
Figma: https://www.figma.com/file/AMtQECMzDn4EXf4geUmzUI/%5BVENDOR%5D-Framic?node-id=3379%3A20518
Task: https://phabricator.sirclo.com/T38764
Previous PR: https://github.com/sirclo-solution/template-framic/pull/52

Proof of work:
[enable coupon detail button.webm](https://user-images.githubusercontent.com/55394860/196877069-f6befe11-6e8f-4f91-9411-5bc7f3b1a95c.webm)

- adjust showmore container margin
![adjust showmore container margin](https://user-images.githubusercontent.com/55394860/196877540-dd3fe113-8ef9-4c7c-9217-8fcd12e7b4df.png)
