### PR TITLE
fix: product description with image

### DIFF
--- a/public/scss/components/ProductDetail.module.scss
+++ b/public/scss/components/ProductDetail.module.scss
@@ -259,9 +259,11 @@
     color: $color_grey;
     margin-bottom: 34px;
 
-    ul, p
+    width: 100%;
+
+    img
     {
-      margin: 0
+      max-width: 100% !important;
     }
   }
 


### PR DESCRIPTION
### Problem

1. Ketika menggunakan size guide tapi tanpa tambahan description lainnya, maka tabelnya kurang lebar (karena mengikuti width dari div product description) -> solusi hrs ditambahin width: 100%
2. Ketika ditambahin image dengan ukuran yg melebihi spacenya di product description maka widthnya melebihi container -> solusi di imagenya hrs ditambahin max-width: 100%


### **Problem 1:**
### Before:
<img width="1350" alt="Screen Shot 2022-12-02 at 14 22 41" src="https://user-images.githubusercontent.com/8541505/205238367-4d29d470-c20a-4ea5-b119-16616c8402dd.png">

### After:
<img width="1367" alt="Screen Shot 2022-12-02 at 14 27 52" src="https://user-images.githubusercontent.com/8541505/205238778-9060bcad-2588-49a7-b313-4c8381477c71.png">


### **Problem 2:**
### Before:
<img width="1434" alt="Screen Shot 2022-12-02 at 14 15 08" src="https://user-images.githubusercontent.com/8541505/205238990-578836a1-989f-4f2f-bc85-5c84d8b7b503.png">
<img width="574" alt="Screen Shot 2022-12-02 at 14 20 20" src="https://user-images.githubusercontent.com/8541505/205239130-8e28f820-be15-4b03-95c1-1878e6900c29.png">

### After:
<img width="1428" alt="Screen Shot 2022-12-02 at 14 18 35" src="https://user-images.githubusercontent.com/8541505/205239077-d20c9bf3-f375-433e-a037-c133d01bd8de.png">
<img width="525" alt="Screen Shot 2022-12-02 at 14 19 47" src="https://user-images.githubusercontent.com/8541505/205240213-29abfb1e-57be-4ebc-9b55-e4b2b9e27117.png">


