### PR TITLE
fix(account): add dashed bottom border to order history header

### DIFF
--- a/public/scss/pages/Account.module.scss
+++ b/public/scss/pages/Account.module.scss
@@ -728,16 +728,23 @@
     @include flex(row, center, space-between);
     order: 2;
     width: calc(100% - 32px);
-    margin:  0 16px;
-    background: $color_light_dark;
+    margin: 0 16px;
     border-radius: 3px;
-    padding: 8px 12px;
+    border-top: 1px dashed $color_grey_light_border;
+
+    & > span,
+    & > h2
+    {
+      width: 100%;
+      margin-top: 16px;
+      padding: 8px 12px;
+      background: $color_light_dark;
+      color: $color_black_text;
+    }
 
     & > span
     {
       @include typographyBuilder(500, 12, 16);
-      color: $color_black_text;
-      margin: 0;
     }
   }
 


### PR DESCRIPTION
Figma:
![Screenshot from 2023-01-23 09-19-19](https://user-images.githubusercontent.com/40454642/213955671-19dd5cd8-f5aa-49c9-858a-c4ea33f781ad.png)
![Screenshot from 2023-01-23 09-18-56](https://user-images.githubusercontent.com/40454642/213955681-ace51828-fd9d-40da-8206-a3e82ca14cbe.png)
Before:
[Screencast from 21-01-23 09:18:43.webm](https://user-images.githubusercontent.com/40454642/213839649-9f7c01ba-0cc1-493a-8d7a-b568944fd65d.webm)
After:
[Screencast from 21-01-23 09:19:04.webm](https://user-images.githubusercontent.com/40454642/213839654-1b4e8ec3-b1f0-4ca6-894b-a796013a1f3d.webm)