### PR TITLE
fix(homepage): add spaces between widget images

### DIFF
--- a/public/scss/components/WidgetHomePage.module.scss
+++ b/public/scss/components/WidgetHomePage.module.scss
@@ -145,6 +145,7 @@
   &_itemBottom
   {
     position: relative;
+    margin-top: 12px;
 
     &:hover{
       cursor: pointer;


### PR DESCRIPTION
POW
![image](https://user-images.githubusercontent.com/38358288/219547429-2fe8bfb8-022f-45d2-be8f-f1cc165abf16.png)
![image](https://user-images.githubusercontent.com/38358288/219547474-3353caf3-13bb-47bf-820c-82e8d419d974.png)
