### PR TITLE
fix(homepage): add object fit cover to mobile category image

### DIFF
--- a/public/scss/components/Product.module.scss
+++ b/public/scss/components/Product.module.scss
@@ -262,6 +262,7 @@
       border: none;
       padding: 0;
       width: 100%;
+      object-fit: cover;
     }
   }
 


### PR DESCRIPTION
**Before:**
![Screenshot from 2023-03-15 12-01-00](https://user-images.githubusercontent.com/40454642/225211421-724dfb58-a791-4579-aba0-f58c18234fcb.png)
![Screenshot from 2023-03-15 11-57-54](https://user-images.githubusercontent.com/40454642/225211432-e509cb97-2018-45d8-9413-532b6c9372e3.png)
[replicated on staging]:
![Screenshot from 2023-03-15 11-58-20](https://user-images.githubusercontent.com/40454642/225211502-34208c35-1bd5-474a-8220-8e5a4f529931.png)

**After:**
![Screenshot from 2023-03-15 11-59-43](https://user-images.githubusercontent.com/40454642/225211521-cc34502c-a6c4-4dfb-a1fe-51304f7114ec.png)
[desktop unchanged]
![Screenshot from 2023-03-15 11-59-46](https://user-images.githubusercontent.com/40454642/225211548-a0ca4f2a-c527-4efe-9d99-23e273d9529e.png)