### PR TITLE
fix(homepage): add object fit cover to mobile category image

### DIFF
--- a/public/scss/components/Product.module.scss
+++ b/public/scss/components/Product.module.scss
@@ -262,6 +262,7 @@
       border: none;
       padding: 0;
       width: 100%;
+      object-fit: cover;
     }
   }
 


### PR DESCRIPTION
Fix
https://github.com/sirclo-solution/template-framic/pull/109