### PR TITLE
fix(product-component): adjust totalProducts usage to relevant components only

### DIFF
--- a/components/ProductsComponent/index.tsx
+++ b/components/ProductsComponent/index.tsx
@@ -109,7 +109,7 @@ const ProductsComponent: FC<ProductsComponentType> = ({
 }) => {
   const [totalProducts, setTotalProducts] = useState(null)
 
-  if (totalProducts === 0 && type !== "list") return <></>
+  if (totalProducts === 0 && (type === "widget" || type === "recomendation")) return <></>
 
   return type === "list" ? (
     <ProductsList


### PR DESCRIPTION
Penyebab bug ini adalah adanya pengecekan ini `if (totalProducts === 0 && type !== "list") return <></>` yang menyebabkan bisa ngebalikin empty html kalau totalProducts 0

Root cause dari problem ini terletak di komponen <TemplateFeatures/> dari nexus, komponen ini mengembalikan kondisi render di sisi client side dengan conditional yang seperti ini:

```
if (features[id]?.isEnabled) {
        return children
      }
return defaultChildren
```

Hal ini menyebabkan `defaultChildren` tetap akan di render meskipun data `features[id]?.isEnabled)` masih berstatus falsy karena data nya masih dalam proses di fetch dari API. Bisa terliat dari screenshot logging berikut bahwa `defaultChildren` masih di render
baru kemudian ditumpuk oleh `children`.

![Screenshot from 2023-05-17 15-53-20](https://github.com/sirclo-solution/template-framic/assets/40454642/b80187dd-08b8-4412-8517-a37df59874e3)

Terlihat dari SS di atas juga kalau state `totalProducts` ikut terbawa value nya ke type `'highlight 1'` meskipun intensi nya cuma digunakan untuk type `widget`. Jadi misal `totalProducts` dari widget 0 maka ada kemungkinan `highlight 1` tidak di render. Maka fix yang saya ajukan seperti di PR ini, hanya akan mengembalikan empty component untuk type 'widget' dan `recomendation` yang memang menggunakan state `totalProducts` di dalam nya.

Notes, state `totalProducts` ini kondisi nya intermitten sekali saya juga bingung kenapa bisa agak random gini:

![Screenshot from 2023-05-17 15-46-23](https://github.com/sirclo-solution/template-framic/assets/40454642/8f96333a-abf7-493d-a318-0e5fb730ead0)

Sebenernya ideal ditambahin pengecekan juga dari sisi <TemplateFeatures/> agar ngebalikin kosongan kalau belum ada data feature flag (ini bisa improve performance juga harusnya karena client jadi ga render useless elements), tapi karena itu butuh fixing dari nexus, quick fix nya dari template bisa seperti ini