### PR TITLE
chore: bump 2.19.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@brainhubeu/react-carousel": "^1.19.14",
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.3",
+    "@sirclo/nexus": "2.19.5",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
template runs normally, build OK
![image](https://github.com/sirclo-solution/template-framic/assets/38358288/3081c6d8-2ea1-4ce9-9d90-116500fb3102)
![image](https://github.com/sirclo-solution/template-framic/assets/38358288/850406a3-6561-4cdc-988f-ea0aa541c497)
