### PR TITLE
chore: bump version nexus 2.19.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@brainhubeu/react-carousel": "^1.19.14",
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.5",
+    "@sirclo/nexus": "2.19.9",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
Task: [[Framic] Bump version nexus 2.19.9](https://phabricator.sirclo.com/T50386)

**Local build aman**
![image](https://github.com/sirclo-solution/template-framic/assets/16263184/a607063d-52c1-47f1-8539-3c76b4ded96f)

test di site id test-merlin
**fix product stock minus: **
![image](https://github.com/sirclo-solution/template-framic/assets/16263184/5d2ecc44-d3bf-4334-b763-d50945e33568)
![image](https://github.com/sirclo-solution/template-framic/assets/16263184/0d3ae980-531e-42c7-abd8-1fab2f5482ac)
