### PR TITLE
fix(place-order): popup detail address in mobile

### DIFF
--- a/public/scss/components/MapLocation.module.scss
+++ b/public/scss/components/MapLocation.module.scss
@@ -139,8 +139,8 @@
 
   @media (max-width: #{$breakpoint_max_md})
   {
+    @include fixedHeight(100%);
     width: 100%;
-    height: 100%;
   }
 }
 


### PR DESCRIPTION
ada yang kelewat ternyata commitan nya belum saya push 

<html>
<body>
<!--StartFragment-->

Item test | Before | After
--  | --  | -- 
Popup detail address  | ![image](https://github.com/sirclo-solution/template-framic/assets/16263184/8e1969b9-acb1-4f52-a1e5-aa7bb29faa7b) | ![image](https://github.com/sirclo-solution/template-framic/assets/16263184/bb31012f-b0e6-4f2d-a939-db31f5774ed1)
<!--EndFragment-->
</body>
</html>	
<br class="Apple-interchange-newline"><!--EndFragment-->