### PR TITLE
Fix: remove width from thumbor settings in product details

### DIFF
--- a/components/ProductDetailComponent/index.tsx
+++ b/components/ProductDetailComponent/index.tsx
@@ -22,7 +22,6 @@ import ProductDetailReviews from './ProductDetailReviews'
 import styles from 'public/scss/components/ProductDetail.module.scss'
 import stylesButton from 'public/scss/components/Button.module.scss'
 import stylesForm from 'public/scss/components/Form.module.scss'
-import { useSizeBanner } from 'lib/useSizeBanner'
 
 type ProductDetailComponentType = {
   data: any
@@ -173,7 +172,6 @@ const ProductDetailComponent: FC<ProductDetailComponentType> = ({
         prevIcon={<span className={styles.productdetail_arrowPrev} />}
         nextIcon={<span className={styles.productdetail_arrowNext} />}
         thumborSetting={{
-          width: useSizeBanner(size.width),
           format: "webp",
           quality: 100
         }}


### PR DESCRIPTION
Proof of work:
local:
![image](https://github.com/sirclo-solution/template-framic/assets/60541277/f6419604-0115-4ed7-bf40-8ce1ac8f43ef)

staging:
![image](https://github.com/sirclo-solution/template-framic/assets/60541277/56c2e2b2-c30d-4694-a877-b2843b27f7f5)
