### PR TITLE
Fix: remove width from thumbor settings in product details

### DIFF
--- a/components/ProductDetailComponent/index.tsx
+++ b/components/ProductDetailComponent/index.tsx
@@ -24,7 +24,6 @@ import styles from 'public/scss/components/ProductDetail.module.scss'
 import stylesButton from 'public/scss/components/Button.module.scss'
 import stylesForm from 'public/scss/components/Form.module.scss'
 import stylesSizeGuide from 'public/scss/components/SizeGuide.module.scss'
-import { useSizeBanner } from 'lib/useSizeBanner'
 
 type ProductDetailComponentType = {
   data: any
@@ -265,7 +264,6 @@ const ProductDetailComponent: FC<ProductDetailComponentType> = ({
         prevIcon={<span className={styles.productdetail_arrowPrev} />}
         nextIcon={<span className={styles.productdetail_arrowNext} />}
         thumborSetting={{
-          width: useSizeBanner(size.width),
           format: "webp",
           quality: 100
         }}


### PR DESCRIPTION
Proof of work:
local:

![image](https://github.com/sirclo-solution/template-framic/assets/60541277/544150fe-1aa4-49a7-b5c0-51469bdafe8a)
staging:
![image](https://github.com/sirclo-solution/template-framic/assets/60541277/b7a5c8fc-24fb-4fcc-9468-c43f39b7a5e0)
