### PR TITLE
Fix: remove width from thumbor settings in product details

### DIFF
--- a/components/ProductDetailComponent/index.tsx
+++ b/components/ProductDetailComponent/index.tsx
@@ -24,7 +24,6 @@ import styles from 'public/scss/components/ProductDetail.module.scss'
 import stylesButton from 'public/scss/components/Button.module.scss'
 import stylesForm from 'public/scss/components/Form.module.scss'
 import stylesSizeGuide from 'public/scss/components/SizeGuide.module.scss'
-import { useSizeBanner } from 'lib/useSizeBanner'
 
 type ProductDetailComponentType = {
   data: any
@@ -265,7 +264,6 @@ const ProductDetailComponent: FC<ProductDetailComponentType> = ({
         prevIcon={<span className={styles.productdetail_arrowPrev} />}
         nextIcon={<span className={styles.productdetail_arrowNext} />}
         thumborSetting={{
-          width: useSizeBanner(size.width),
           format: "webp",
           quality: 100
         }}


### PR DESCRIPTION
Proof of work:
local:
![image](https://github.com/sirclo-solution/template-framic/assets/60541277/8c39eadc-9af9-4edd-b9b3-2d39363df079)
staging:
![image](https://github.com/sirclo-solution/template-framic/assets/60541277/6c4cc395-d7e1-4690-b94a-824245461705)
